### PR TITLE
Make Ubuntu prebuilds in a container

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -9,9 +9,11 @@ jobs:
           - os: ubuntu-22.04
             platform: linux
             arch: x64
+            container: ubuntu:20.04
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
+            container: ubuntu:20.04
           - os: ubuntu-22.04
             platform: android
             arch: x64
@@ -54,6 +56,7 @@ jobs:
             platform: win32
             arch: arm64
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -66,7 +66,11 @@ jobs:
       - run: |
           apt update
           apt install -y meson nasm
-        if: ${{ matrix.platform == 'linux' || matrix.platform == 'android' }}
+        if: ${{ matrix.platform == 'linux' }}
+      - run: |
+          sudo apt update
+          sudo apt install -y meson nasm
+        if: ${{ matrix.platform == 'android' }}
       - run: brew install meson nasm
         if: ${{ matrix.platform == 'darwin' || matrix.platform == 'ios' }}
       - run: |

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -65,7 +65,7 @@ jobs:
           node-version: lts/*
       - run: |
           apt update
-          apt install -y meson nasm
+          apt install -y git clang lld meson nasm
         if: ${{ matrix.platform == 'linux' }}
       - run: |
           sudo apt update

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -9,11 +9,11 @@ jobs:
           - os: ubuntu-22.04
             platform: linux
             arch: x64
-            container: ubuntu:20.04
+            container: ubuntu:22.04
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
-            container: ubuntu:20.04
+            container: ubuntu:22.04
           - os: ubuntu-22.04
             platform: android
             arch: x64

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -64,8 +64,8 @@ jobs:
         with:
           node-version: lts/*
       - run: |
-          sudo apt update
-          sudo apt install -y meson nasm
+          apt update
+          apt install -y meson nasm
         if: ${{ matrix.platform == 'linux' || matrix.platform == 'android' }}
       - run: brew install meson nasm
         if: ${{ matrix.platform == 'darwin' || matrix.platform == 'ios' }}


### PR DESCRIPTION
The public GitHub Actions Ubuntu image is a bit too liberal in updating things like the GNU C and C++ libraries, causing issues for consumers of the prebuilds.